### PR TITLE
Remove height from image tags, so scaling happens proportionally

### DIFF
--- a/src/components/MyCharacters/myCharacter.jsx
+++ b/src/components/MyCharacters/myCharacter.jsx
@@ -108,7 +108,6 @@ class MyCharacter extends Component {
                     src={`/images/${playerCharacter.characterName}.jpg`}
                     alt="Unable to load img"
                     width="95%"
-                    height="320"
                   />
                 </p>
                 <p>

--- a/src/components/OtherCharacters/OtherCharacters.jsx
+++ b/src/components/OtherCharacters/OtherCharacters.jsx
@@ -140,7 +140,7 @@ class OtherCharacters extends Component {
 								<p>{this.state.selected.bio}</p>
 								<Divider></Divider>
 
-								<img src={`/images/${this.state.selected.characterName}.jpg`} alt="Img could not be displayed" width="320" height="320" />
+								<img src={`/images/${this.state.selected.characterName}.jpg`} alt="Img could not be displayed" width="320" />
 
 							</Panel>
 						</FlexboxGrid.Item>


### PR DESCRIPTION
Only one of width or height should be specified, so scaling of the image happens proportionally. If both are present and the source image does not have the same proportion then the image will be distorted.